### PR TITLE
两处修改

### DIFF
--- a/src/delogo.hpp
+++ b/src/delogo.hpp
@@ -102,19 +102,23 @@ public:
 	}
 
 	inline int YtoAUY(int y) {
-		return ((y * 1197) >> 6) - 299;
+		//return ((y - 16) * 1197 + 32) >> 6;
+		return (y * 1197 - 19120) >> 6;
 	}
 
 	inline int CtoAUC(int c) {
-		return (c * 4681 - 128 * 4681 + 164) >> 8;
+		//return ((c - 128) * 4681 + 128) >> 8;
+		return (c * 4681 - 599040) >> 8;
 	}
 
 	inline int AUYtoY(int y) {
-		return Clamp((y * 219 + 383 + (16 << 12)) >> 12, 0, 255);
+		//return Clamp(((y * 219 + 2048) >> 12) + 16, 0, 255);
+		return Clamp((y * 219 + 67584) >> 12, 0, 255);
 	}
 
 	inline int AUCtoC(int c) {
-		return Clamp((c * 7 + 2048 * 7 + 66 + (16 << 7)) >> 7, 0, 255);
+		//return Clamp(((c * 7 + 64) >> 7) + 128, 0, 255);
+		return Clamp((c * 7 + 16448) >> 7, 0, 255);
 	}
 };
 

--- a/src/delogo_yv12.cpp
+++ b/src/delogo_yv12.cpp
@@ -22,65 +22,108 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301, USA
 static void ConvertUV(LOCAL_LOGO_PIXEL * dst, LOGO_PIXEL * src, const LOGO_HEADER & m_lgh,
                       bool oddx, bool oddy, bool oddw, bool oddh,
                       int(* DP)(LOGO_PIXEL *), int(* Cx)(LOGO_PIXEL *)) {
-	const int srcw = m_lgh.w - (oddx ? 1 : 0) - (oddw ? 1 : 0);
-	const int srch = m_lgh.h - (oddy ? 1 : 0) - (oddh ? 1 : 0);
-	const int srcw_r = (srcw - (oddx ? 1 : 0) - (oddw ? 1 : 0)) / 2 + (oddw ? 1 : 0); // one more if oddw=t
-	const int srch_r = (srch - (oddy ? 1 : 0) - (oddh ? 1 : 0)) / 2;
-	LOGO_PIXEL * s1 = src;
+	const int srcw = m_lgh.w - oddx - oddw;
+	const int srch = m_lgh.h - oddy - oddh;
+	const int srcw_r = (srcw - oddx - oddw) >> 1;
+	const int srch_r = (srch - oddy - oddh) >> 1;
+	int i, j, dp;
+	LOGO_PIXEL * s00 = src;
+	LOGO_PIXEL * s01 = s00 + 1;
 
 	if (oddy) {
 		if (oddx) {
-			dst->dp = 0;
+			dst->dp = (DP(s00) + 2) >> 2;
+			dst->c = Cx(s00);
 			++dst;
-			++s1;
+			++s00;
+			++s01;
 		}
-		for (int j = srcw_r; j; --j) {
-			dst->dp = (DP(s1) + 1) / 2;
-			dst->c = Cx(s1);
-			++dst;
-			s1 += 2;
-		}
-		if (oddw) { // Move back if move too much
-			--s1;
-		}
-	}
-	LOGO_PIXEL * s2 = s1 + srcw;
-	for (int i = srch_r; i; --i) {
-		if (oddx) {
-			dst->dp = 0;
-			++dst;
-			++s1;
-			++s2;
-		}
-		for (int j = srcw_r; j; --j) {
-			int dp = DP(s1) + DP(s2);
-			dst->dp = (dp + 1) / 2;
+		for (j = srcw_r; j; --j) {
+			dp = DP(s00) + DP(s01);
+			dst->dp = (dp + 2) >> 2;
 			if (dp) {
-				dst->c = (Cx(s1) * DP(s1)
-					+ Cx(s2) * DP(s2) + (dp + 1) / 2) / dp;
+				dst->c = (Cx(s00) * DP(s00) + Cx(s01) * DP(s01) + ((dp + 1) >> 1)) / dp;
 			}
 			++dst;
-			s1 += 2;
-			s2 += 2;
+			s00 += 2;
+			s01 += 2;
 		}
 		if (oddw) {
-			--s1;
-			--s2;
+			dst->dp = (DP(s00) + 2) >> 2;
+			dst->c = Cx(s00);
+			++dst;
+			++s00;
+			++s01;
 		}
-		s1 += srcw;
-		s2 += srcw;
+	}
+	LOGO_PIXEL * s10 = s00 + srcw;
+	LOGO_PIXEL * s11 = s01 + srcw;
+	for (i = srch_r; i; --i) {
+		if (oddx) {
+			dp = DP(s00) + DP(s10);
+			dst->dp = (dp + 2) >> 2;
+			if (dp) {
+				dst->c = (Cx(s00) * DP(s00) + Cx(s10) * DP(s10) + ((dp + 1) >> 1)) / dp;
+			}
+			++dst;
+			++s00;
+			++s01;
+			++s10;
+			++s11;
+		}
+		for (j = srcw_r; j; --j) {
+			dp = DP(s00) + DP(s01) + DP(s10) + DP(s11);
+			dst->dp = (dp + 2) >> 2;
+			if (dp) {
+				dst->c = (Cx(s00) * DP(s00) + Cx(s01) * DP(s01) + Cx(s10) * DP(s10) + Cx(s11) * DP(s11) + ((dp + 1) >> 1)) / dp;
+			}
+			++dst;
+			s00 += 2;
+			s01 += 2;
+			s10 += 2;
+			s11 += 2;
+		}
+		if (oddw) {
+			dp = DP(s00) + DP(s10);
+			dst->dp = (dp + 2) >> 2;
+			if (dp) {
+				dst->c = (Cx(s00) * DP(s00) + Cx(s10) * DP(s10) + ((dp + 1) >> 1)) / dp;
+			}
+			++dst;
+			++s00;
+			++s01;
+			++s10;
+			++s11;
+		}
+		s00 += srcw;
+		s01 += srcw;
+		s10 += srcw;
+		s11 += srcw;
 	}
 	if (oddh) {
 		if (oddx) {
-			dst->dp = 0;
+			dst->dp = (DP(s00) + 2) >> 2;
+			dst->c = Cx(s00);
 			++dst;
-			++s1;
+			++s00;
+			++s01;
 		}
-		for (int j = srcw_r; j; --j) {
-			dst->dp = (DP(s1) + 1) / 2;
-			dst->c = Cx(s1);
+		for (j = srcw_r; j; --j) {
+			dp = DP(s00) + DP(s01);
+			dst->dp = (dp + 2) >> 2;
+			if (dp) {
+				dst->c = (Cx(s00) * DP(s00) + Cx(s01) * DP(s01) + ((dp + 1) >> 1)) / dp;
+			}
 			++dst;
-			s1 += 2;
+			s00 += 2;
+			s01 += 2;
+		}
+		if (oddw) {
+			dst->dp = (DP(s00) + 2) >> 2;
+			dst->c = Cx(s00);
+			++dst;
+			++s00;
+			++s01;
 		}
 	}
 }
@@ -101,8 +144,8 @@ static void ConvertV(LOCAL_LOGO_PIXEL * dst, LOGO_PIXEL * src, const LOGO_HEADER
 
 static void ConvertY(LOCAL_LOGO_PIXEL * dst, LOGO_PIXEL * src, const LOGO_HEADER & m_lgh, bool oddx, bool oddy, bool oddw, bool oddh) {
 	const int w = m_lgh.w;
-	const int srcw = w - (oddx ? 1 : 0) - (oddw ? 1 : 0);
-	const int srch = m_lgh.h - (oddy ? 1 : 0) - (oddh ? 1 : 0);
+	const int srcw = w - oddx - oddw;
+	const int srch = m_lgh.h - oddy - oddh;
 	if (oddy) {
 		for (int i = w; i; --i) {
 			dst->dp = 0;


### PR DESCRIPTION
整理了一下天书般的式子。。。
AU的Y范围是0～4096，UV是-2048～2048，直接对应过去
但是有几个数有出入，可以对比一下注释里的式子和原来的，我不知道原作者是什么意图，只是觉得没有道理

原来的 ConvertUV() 函数让 logo 的 1/4 像素调整基本作废，在此改正
顺带去掉 (bool ? 1 : 0) 这种奇怪的东西
