### PR TITLE
fix memory leak

### DIFF
--- a/src/delogo.cpp
+++ b/src/delogo.cpp
@@ -50,6 +50,8 @@ delogo::delogo(const VSAPI *vsapi,
 		lgd = AlphaCutoff(lgd);
 
 	m_lgd = Convert(lgd, m_lgh);
+
+	delete[] lgd;
 }
 
 LOGO_PIXEL* delogo::ReadLogoData() {

--- a/src/delogo_interface.cpp
+++ b/src/delogo_interface.cpp
@@ -29,8 +29,7 @@ void VS_CC
 logoFree(void *instanceData, VSCore *core, const VSAPI *vsapi)
 {
 	delogo *d = static_cast<delogo*>(instanceData);
-	// This can cause deadlock under Linux. FIXME
-	// vsapi->freeNode(d->node);
+	vsapi->freeNode(d->node);
 	delete d;
 }
 


### PR DESCRIPTION
deadlock 的问题 vapoursynth 应该已经解决了，没必要注视掉释放内存的语句。。。
